### PR TITLE
Update README run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `indexOf` method finds the first location of the pattern in the target. The 
 
 The Scout implementation is described and compared against alternative algorithms in http://www.anandnatrajan.com/papers/CACM20a.pdf. This paper has been submitted to Communications of the ACM for publication under the title "Scout Algorithm for Fast Substring Matching", by A. Natrajan and M. Anand. A longer version with a detailed walkthrough of the algorithm and expanded comparisons is at arXiv, and can also be downloaded from http://www.anandnatrajan.com/papers/ARXIV20.pdf.
 
-The algorithm and test cases can be compiled with `javac com/amobee/commons/utils/StringUtils.java`. There are no dependencies required other than a standard Java installation. The command `java com/amobee/commons/utils/StringUtils` can be run subsequently to run several test cases that compare the output of the Scout version of indexOf against the Java built-in version.
+The algorithm and test cases can be compiled with `javac com/amobee/commons/utils/StringUtils.java`. There are no dependencies required other than a standard Java installation. The command `java com.amobee.commons.utils.StringUtils` can be run subsequently to run several test cases that compare the output of the Scout version of indexOf against the Java built-in version.
 
 The self-contained snippet below shows how to use the method. Cut and paste it into a file named `SUTest.java`, and compile and run it with the appropriate classpath to see it work.
 ```


### PR DESCRIPTION
Switched the README instructions to use the dot `.` separator for running the compiled Java class. The current instructions work, but the dot separator will work cross-platform (Windows) and allows for tab-completion on modern shells, such as zsh on macOS.